### PR TITLE
docs(ui-components): ui-collapse correct param for opened state

### DIFF
--- a/resources/views/examples/components/collapse-show.blade.php
+++ b/resources/views/examples/components/collapse-show.blade.php
@@ -1,3 +1,3 @@
-<x-moonshine::collapse title="Hide / Show" :show="true"><!-- [tl! focus] -->
+<x-moonshine::collapse title="Hide / Show" open="true"><!-- [tl! focus] -->
     {{ fake()->text() }}
 </x-moonshine::collapse><!-- [tl! focus] -->


### PR DESCRIPTION
Исправлен параметр который показывает компонент collapse открытым. 