### PR TITLE
docs(fields): BelongsToMany updated ->inLine method

### DIFF
--- a/resources/views/pages/en/fields/belongs_to_many.blade.php
+++ b/resources/views/pages/en/fields/belongs_to_many.blade.php
@@ -216,9 +216,12 @@ inLine(string $separator = '', bool $badge = false, ?Closure $link = null)
     You can pass optional parameters to the method:
     <x-ul>
         <li><code>separator</code> - separator between elements;</li>
-        <li><code>badge</code> - display elements as badge;</li>
+        <li><code>badge</code> - closure or boolean value, responsible for displaying elements as badge;</li>
         <li><code>$link</code> - a closure that should return <em>url</em> links or components.</li>
     </x-ul>
+</x-p>
+<x-p>
+    When passing the boolean value true to the <code>badge</code> parameter, the color  will be used <x-moonshine::badge color="primary">Primary</x-moonshine::badge>. To change the color displayed by <code>badge</code>, use closure and return the <code>Badge::make()</code> component.
 </x-p>
 
 <x-code language="php">

--- a/resources/views/pages/en/fields/belongs_to_many.blade.php
+++ b/resources/views/pages/en/fields/belongs_to_many.blade.php
@@ -236,7 +236,7 @@ public function fields(): array
         BelongsToMany::make('Categories', resource: new CategoryResource())
             ->inLine(
                 separator: ' ',
-                badge: true,
+                badge: fn($model, $value) => Badge::make($value, 'color'),
                 link: fn(Category $category, $value, $field) => Link::make(
                     (new CategoryResource())->detailPageUrl($category),
                     $value

--- a/resources/views/pages/en/fields/belongs_to_many.blade.php
+++ b/resources/views/pages/en/fields/belongs_to_many.blade.php
@@ -209,7 +209,7 @@ public function fields(): array
 </x-p>
 
 <x-code language="php">
-inLine(string $separator = '', bool $badge = false, ?Closure $link = null)
+inLine(string $separator = '', Closure|bool $badge = false, ?Closure $link = null)
 </x-code>
 
 <x-p>

--- a/resources/views/pages/ru/fields/belongs_to_many.blade.php
+++ b/resources/views/pages/ru/fields/belongs_to_many.blade.php
@@ -209,16 +209,19 @@ public function fields(): array
 </x-p>
 
 <x-code language="php">
-inLine(string $separator = '', bool $badge = false, ?Closure $link = null)
+inLine(string $separator = '', Closure|bool $badge = false, ?Closure $link = null)
 </x-code>
 
 <x-p>
     Методу можно передать необязательные параметры:
     <x-ul>
         <li><code>separator</code> - разделитель между элементами;</li>
-        <li><code>badge</code> - отображать элементы в виде badge;</li>
+        <li><code>badge</code> - замыкание или булево значение, отвечающий за отображение элемента в виде badge;</li>
         <li><code>$link</code> - замыкание которое должно вернуть <em>url</em> ссылки или компонент.</li>
     </x-ul>
+</x-p>
+<x-p>
+    При передаче булевого значения true в параметр <code>badge</code> будет использоваться цвет <x-moonshine::badge color="primary">Primary</x-moonshine::badge>. Для изменения цвета, отображаемого <code>badge</code>, используйте замыкание и возвращайте компонент <code>Badge::make()</code>.
 </x-p>
 
 <x-code language="php">
@@ -233,7 +236,7 @@ public function fields(): array
         BelongsToMany::make('Categories', resource: new CategoryResource())
             ->inLine(
                 separator: ' ',
-                badge: true,
+                badge: fn($model, $value) => Badge::make($value, 'color'),
                 link: fn(Category $category, $value, $field) => Link::make(
                     (new CategoryResource())->detailPageUrl($category),
                     $value


### PR DESCRIPTION
Обновил русскую и английскую версии документации метода `->inLine()` поля BelongsToMany.

![image](https://github.com/moonshine-software/doc/assets/73887319/edbe0d3e-736f-4e0d-abac-244d7ba18e36)
![image](https://github.com/moonshine-software/doc/assets/73887319/dd6e2c50-284a-4e81-a1fb-ef3edee48f12)
