### PR TITLE
fix: Replace Choices with Tom Select

### DIFF
--- a/en/fields/belongs-to-many.md
+++ b/en/fields/belongs-to-many.md
@@ -250,12 +250,12 @@ use MoonShine\Laravel\Fields\Relationships\BelongsToMany;
 BelongsToMany::make('Categories', resource: CategoryResource::class)
     ->selectMode()
     ->customAttributes([
-        'data-max-item-count' => 2
+        'data-search-enabled' => true,
     ])
 ```
 
 > [!NOTE]
-> For more detailed information, please refer to [Choices](https://choices-js.github.io/Choices/).
+> For more detailed information, please refer to the [Tom Select documentation](https://tom-select.js.org/docs/).
 
 <a name="placeholder"></a>
 ## Placeholder

--- a/en/fields/belongs-to.md
+++ b/en/fields/belongs-to.md
@@ -415,17 +415,17 @@ use MoonShine\Laravel\Fields\Relationships\BelongsTo;
 BelongsTo::make('Country', resource: CountryResource::class)
     ->searchable()
     ->customAttributes([
-        'data-search-result-limit' => 5
+        'data-associated-with' => 'country_id',
     ])
 ```
 
 > [!NOTE]
-> For more detailed information, please refer to [Choices](https://choices-js.github.io/Choices/).
+> For more detailed information, please refer to the [Tom Select documentation](https://tom-select.js.org/docs/).
 
 <a name="native"></a>
 ## Native Mode
 
-The `native()` method disables the Choices.js library and displays the selection in native mode.
+The `native()` method disables the *Tom Select* library and displays the selection in native mode.
 
 ```php
 use MoonShine\Laravel\Fields\Relationships\BelongsTo;

--- a/en/fields/select.md
+++ b/en/fields/select.md
@@ -492,7 +492,7 @@ new OptionProperty(
 <a name="options"></a>
 ## Options
 
-All *Choices.js* options are available for modification through *data attributes*.
+All *Tom Select* options are available for modification through *data attributes*.
 
 ```php
 use MoonShine\UI\Fields\Select;
@@ -503,18 +503,18 @@ Select::make('Country', 'country_id')
         2 => 'United Arab Emirates',
     ])
     ->customAttributes([
-        'data-max-item-count' => 2
+        'data-remove-item-button' => true,
     ])
 
 ```
 
 > [!TIP]
-> For more detailed information refer to the [Choices.js](https://choices-js.github.io/Choices/).
+> For more detailed information refer to the [Tom Select documentation](https://tom-select.js.org/docs/).
 
 <a name="native"></a>
 ## Native display mode
 
-The `native()` method disables the *Choices.js* library and outputs the `Select` in native mode.
+The `native()` method disables the *Tom Select* library and outputs the `Select` in native mode.
 
 ```php
 use MoonShine\UI\Fields\Select;

--- a/ru/fields/belongs-to-many.md
+++ b/ru/fields/belongs-to-many.md
@@ -251,12 +251,12 @@ use MoonShine\Laravel\Fields\Relationships\BelongsToMany;
 BelongsToMany::make('Categories', resource: CategoryResource::class)
     ->selectMode()
     ->customAttributes([
-        'data-max-item-count' => 2
+        'data-search-enabled' => true,
     ])
 ```
 
 > [!NOTE]
-> Для получения более подробной информации, пожалуйста, обратитесь к [Choices](https://choices-js.github.io/Choices/).
+> Для получения более подробной информации, пожалуйста, обратитесь к [документации Tom Select](https://tom-select.js.org/docs/).
 
 <a name="placeholder"></a>
 ## Placeholder

--- a/ru/fields/belongs-to.md
+++ b/ru/fields/belongs-to.md
@@ -414,17 +414,17 @@ use MoonShine\Laravel\Fields\Relationships\BelongsTo;
 BelongsTo::make('Country', resource: CountryResource::class)
     ->searchable()
     ->customAttributes([
-        'data-search-result-limit' => 5
+        'data-associated-with' => 'country_id',
     ])
 ```
 
 > [!NOTE]
-> Для получения более подробной информации, пожалуйста, обратитесь к [Choices](https://choices-js.github.io/Choices/).
+> Для получения более подробной информации, пожалуйста, обратитесь к [документации Tom Select](https://tom-select.js.org/docs/).
 
 <a name="native"></a>
 ## Нативный режим
 
-Метод `native()` отключает библиотеку Choices.js и отображает выбор в нативном режиме.
+Метод `native()` отключает библиотеку *Tom Select* и отображает выбор в нативном режиме.
 
 ```php
 use MoonShine\Laravel\Fields\Relationships\BelongsTo;

--- a/ru/fields/select.md
+++ b/ru/fields/select.md
@@ -499,7 +499,7 @@ new OptionProperty(
 <a name="options"></a>
 ## Опции
 
-Все опции *Сhoices.js* доступны для изменения через *data attributes*.
+Все опции *Tom Select* доступны для изменения через *data attributes*.
 
 ```php
 use MoonShine\UI\Fields\Select;
@@ -510,18 +510,18 @@ Select::make('Country', 'country_id')
         2 => 'United Arab Emirates',
     ])
     ->customAttributes([
-        'data-max-item-count' => 2
+        'data-remove-item-button' => true,
     ])
 
 ```
 
 > [!TIP]
-> За более подробной информацией обратитесь к [Choices.js](https://choices-js.github.io/Choices/).
+> За более подробной информацией обратитесь к [документации Tom Select](https://tom-select.js.org/docs/).
 
 <a name="native"></a>
 ## Нативный режим отображения
 
-Метод `native()` отключает библиотеку *Choices.js* и выводит `Select` в нативном режиме.
+Метод `native()` отключает библиотеку *Tom Select* и выводит `Select` в нативном режиме.
 
 ```php
 use MoonShine\UI\Fields\Select;
@@ -581,7 +581,7 @@ Select::make('Type')
 <a name="settings"></a>
 ## Пользовательские настройки
 
-Метод `settings()` разрешает использовать все пользовательские настройки `Tom select`.
+Метод `settings()` разрешает использовать все пользовательские настройки `Tom Select`.
 
 ```php
 use MoonShine\Support\DTOs\Select\Settings;


### PR DESCRIPTION
## Checklist

- Issue #956
- Lang
  - [x] En
  - [x] Ru

Что нашел - поправил. Похоже, что сейчас через `data-` поддерживаются только 3 опции.