### PR TITLE
add-autoload-menu-note

### DIFF
--- a/en/appearance/menu.md
+++ b/en/appearance/menu.md
@@ -293,6 +293,11 @@ final class MoonShineLayout extends AppLayout
 
 You can apply the icon-only mode to the entire menu when using autoload by passing the `onlyIcons: true` parameter to the `autoloadMenu()` method.
 
+> [!NOTE]
+> To use `autoloadMenu()` (including the `onlyIcons: true` mode), you **must also enable menu autoloading for resources and pages**.
+>
+> See the section on [autoloading resources and pages](/docs/{{version}}/model-resource/index#autoloading) for details.
+
 ```php
 // torchlight! {"summaryCollapsedIndicator": "namespaces"}
 // [tl! collapse:3]

--- a/ru/appearance/menu.md
+++ b/ru/appearance/menu.md
@@ -293,6 +293,11 @@ final class MoonShineLayout extends AppLayout
 
 Вы можете применить режим только иконок ко всему меню при использовании автозагрузки, передав параметр `onlyIcons: true` в метод `autoloadMenu()`.
 
+> [!NOTE]
+> Чтобы использовать `autoloadMenu()` (включая режим `onlyIcons: true` для всего меню), **необходимо также включить автозагрузку ресурсов и страниц**.
+>
+> Подробнее см. раздел про [автозагрузку ресурсов и страниц](/docs/{{version}}/model-resource/index#autoloading).
+
 ```php
 // torchlight! {"summaryCollapsedIndicator": "namespaces"}
 // [tl! collapse:3]


### PR DESCRIPTION
Added a [!NOTE] block explaining that in order for `autoloadMenu()` (including the `onlyIcons` mode) to work, you must also enable autoloading of resources and pages.

- Lang
  - [x] En
  - [x] Ru
